### PR TITLE
Fix some small Linux install and and config issues

### DIFF
--- a/gdesk/config/defaults_linux.json
+++ b/gdesk/config/defaults_linux.json
@@ -113,6 +113,7 @@
     },
   "shortcuts": {
     "help": "F1",
+    "application restart": "Shift+F4",
     "panel preview": "Ctrl+Shift+Tab",
     "window preview": "Shift+Tab",
     "instance info": "Shift+F1",

--- a/gdesk/config/defaults_linux.json
+++ b/gdesk/config/defaults_linux.json
@@ -1,7 +1,7 @@
 {
-  "path_log": "$USER/AppData/Local/Gamma-Desk",
+  "path_log": "~/.gamma-desk-log",
   "max_log_paths": 10,
-  "path_config_files": ["$USER/AppData/Local/Gamma-Desk/gdconf.json", "gdconf.json"],
+  "path_config_files": ["~/.config/gamma-desk/gdconf.json", "gdconf.json"],
   "save_config_file": "gdconf.json",
   "init_file": null,
   "init_command": {"cmd": null, "args": []},

--- a/gdesk/core/history.py
+++ b/gdesk/core/history.py
@@ -18,9 +18,11 @@ else:
 from .conf import config
 
 class LogDir(object):
+
     def __init__(self, rootpath):
-        self.rootpath = Path(rootpath)
+        self.rootpath = Path(rootpath).expanduser()
         if not self.rootpath.exists():
+            print(f"Creating log dir: {self.rootpath}")
             self.rootpath.mkdir(parents=True)
 
     def make_lock_file(self, lock_file):

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ PYTHON_REQUIRED = '>=3.6'
 def get_resources():
     found_resources = []    
 
-    found_resources.append(str(modpath / 'config' / 'defaults.json'))
+    if sys.platform == "linux":
+        found_resources.append(str(modpath / 'config' / 'defaults_linux.json'))
+    else:
+        found_resources.append(str(modpath / 'config' / 'defaults.json'))
 
     for path in modpath.glob('resources/**/*'):
         if path.is_dir(): continue

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     'psutil',
     'numba',
     'pyzmq',
-    'pywinpty'
+    'pywinpty; sys_platform=="win32"',
 ]
 
 EXTRAS_REQUIRED = {


### PR DESCRIPTION
* Don't install `pywinpty` on Linux.
* Install the Linux config file when in Linux.
* Expand `~` character in log file path.
* Don't use `$USER/AppData/Gamma-Desk` folders in config.

Wheel files generated on Windows will still contain the Windows config file.