### PR TITLE
Fix: Don't use quotes on the 'edit file' path on Linux

### DIFF
--- a/gdesk/core/shellmod.py
+++ b/gdesk/core/shellmod.py
@@ -12,7 +12,6 @@ import shlex
 import json
 import psutil
 import inspect
-import shlex
 from pathlib import Path
 from itertools import islice
 

--- a/gdesk/core/shellmod.py
+++ b/gdesk/core/shellmod.py
@@ -144,7 +144,11 @@ class Shell(object):
         editorExecutable = Path(config['texteditor'])
         
         if not editorExecutable.exists():
-            logger.error(f"{editorExecutable} doesn't exist")
+            logger.error(
+                f"Text editor executable does not exist: '{editorExecutable}'."
+                "\nAdd to your gdconf.json file file the key 'texteditor', with as value "
+                " the full path to the executable."
+            )
             return
         
         if editorExecutable.name.lower() == 'notepad++.exe':

--- a/gdesk/core/shellmod.py
+++ b/gdesk/core/shellmod.py
@@ -153,8 +153,12 @@ class Shell(object):
         elif editorExecutable.name.lower() == 'code.exe':
             os.spawnl(os.P_NOWAIT, editorExecutable, '"' + str(editorExecutable) + '"',  '-g', f'"{filename}:{lineno}"')
         else:
-            os.spawnl(os.P_NOWAIT, editorExecutable, '"' + str(editorExecutable) + '"', '"{0}"'.format(filename))          
-            
+            if sys.platform == "linux":
+                # Don't use quotes around the file name.
+                os.spawnl(os.P_NOWAIT, editorExecutable, f'"{editorExecutable}"', filename)
+            else:
+                os.spawnl(os.P_NOWAIT, editorExecutable, '"' + str(editorExecutable) + '"', '"{0}"'.format(filename))
+
     def edit_dbase(self, filename):
         """
         Edit a SQLite file with an external editor.


### PR DESCRIPTION
Using a custom `texteditor` was not working for me on Linux.

With this change, it works fine.