### PR TITLE
Feature: Allow objects to hide the class-level attributes from auto-complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 /doc/sphinx/*.log
 /test/stderr.log
 /samples/*.log
+__pycache__/
+gdesk/stderr.log

--- a/gdesk/core/shellmod.py
+++ b/gdesk/core/shellmod.py
@@ -449,11 +449,13 @@ class Shell(object):
         items = []
         for state in range(max):
             if shell.comp.complete.__func__.__code__.co_argcount == 3:
-                #The Python Original rlcompleter
+                # The Python Original rlcompleter.
                 item = shell.comp.complete(text, state)
             else:
+                # Needs an extra argument: 'wild'.
                 item = shell.comp.complete(text, state, wild)
             if item is None:
+                # Reached the end (no more attributes).
                 break
             items.append(item)
         return items        

--- a/gdesk/live/completer.py
+++ b/gdesk/live/completer.py
@@ -215,9 +215,10 @@ class Completer:
 
         # Get the class-level attributes, but only if these are not explicitly hidden.
         hide_class_level_attributes = getattr(thisobject, "_AUTO_COMPLETE_HIDE_CLASS_ATTRIBUTES", False)
-        if hasattr(thisobject, '__class__') and not hide_class_level_attributes:
+        if hasattr(thisobject, '__class__'):
             words.add('__class__')
-            words.update(get_class_members(thisobject.__class__))
+            if not hide_class_level_attributes:
+                words.update(get_class_members(thisobject.__class__))
         matches = []
         n = len(attr)
         if attr == '':

--- a/gdesk/live/completer.py
+++ b/gdesk/live/completer.py
@@ -190,12 +190,13 @@ class Completer:
 
         Assuming the text is of the form NAME.NAME....[NAME], and is
         evaluable in self.namespace, it will be evaluated and its attributes
-        (as revealed by dir()) are used as possible completions.  (For class
-        instances, class members are also considered.)
+        (as revealed by dir()) are used as possible completions.
+
+        For class instances, class members are also considered except if the instance
+        contains a flag `_AUTO_COMPLETE_HIDE_CLASS_ATTRIBUTES` set to True.
 
         WARNING: this can still invoke arbitrary C code, if an object
         with a __getattr__ hook is evaluated.
-
         """
         import re
         #m = re.match(r"(\w+(\.\w+)*)\.(\w*)", text)
@@ -212,7 +213,9 @@ class Completer:
         words = set(dir(thisobject))
         words.discard("__builtins__")
 
-        if hasattr(thisobject, '__class__'):
+        # Get the class-level attributes, but only if these are not explicitly hidden.
+        hide_class_level_attributes = getattr(thisobject, "_AUTO_COMPLETE_HIDE_CLASS_ATTRIBUTES", False)
+        if hasattr(thisobject, '__class__') and not hide_class_level_attributes:
             words.add('__class__')
             words.update(get_class_members(thisobject.__class__))
         matches = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,9 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests"
+]

--- a/tests/live/test_completer.py
+++ b/tests/live/test_completer.py
@@ -1,0 +1,108 @@
+import pytest
+
+from gdesk.live.completer import Completer
+
+
+@pytest.fixture
+def completer():
+    # Set up some objects to auto-complete.
+    without_dir = ClassWithoutDir(a=10, b=20)
+    with_super_dir = ClassWithSuperDir(a=10, b=20)
+    with_dir = ClassWithCustomDir(a=10, b=20)
+    with_dir_and_hide_class = ClassWithCustomDirAndHiddenClassAttributes(a=10, b=20)
+
+    # Return a completer.
+    completer = Completer(namespace=locals())
+    return completer
+
+
+class ParentClass:
+
+    # Expose a class-level constant.
+    CLASS_LEVEL_CONSTANT = 100
+
+    def __init__(self, **kwargs):
+        # Set an attribute at the class level.
+        self.class_level_attribute = "value"
+
+        # Set attributes at the instance level.
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+
+class ClassWithoutDir(ParentClass):
+    """Normal class, inheriting from ParentClass."""
+
+
+class ClassWithSuperDir(ParentClass):
+    """Override __dir__ but simply call parent's __dir__."""
+
+    def __dir__(self):
+        return super().__dir__()
+
+
+class ClassWithCustomDir(ParentClass):
+    """Provide custom __dir__ to limit exposure of instance-level attributes."""
+
+    def __dir__(self):
+        # Hide attribute 'b'.
+        return ["a"]
+
+
+class ClassWithCustomDirAndHiddenClassAttributes(ParentClass):
+    """Provide custom __dir__ *and* configure 'hide class attributes' OFF."""
+
+    _AUTO_COMPLETE_HIDE_CLASS_ATTRIBUTES = True
+
+    def __dir__(self):
+        # Hide attribute 'b'.
+        return ["a"]
+
+
+def _get_all_completions(completer, text):
+    """Return all possible completions in a list."""
+    completions = []
+
+    for i in range(100):
+        completion = completer.complete(text, i)
+        if completion is None:
+            break
+
+        completions.append(completion)
+
+    return completions
+
+
+def test_completer_on_object_without_dir_returns_all_attributes(completer):
+    completed_attributes = _get_all_completions(completer, "without_dir.")
+    assert set(completed_attributes) == set([
+        "without_dir.CLASS_LEVEL_CONSTANT",
+        "without_dir.a",
+        "without_dir.b",
+        "without_dir.class_level_attribute"
+    ])
+
+
+def test_completer_on_object_with_super_dir_returns_all_attributes(completer):
+    completed_attributes = _get_all_completions(completer, "with_super_dir.")
+    assert set(completed_attributes) == set([
+        "with_super_dir.CLASS_LEVEL_CONSTANT",
+        "with_super_dir.a",
+        "with_super_dir.b",
+        "with_super_dir.class_level_attribute"
+    ])
+
+
+def test_completer_on_object_with_custom_dir_returns_dir_attributes_plus_class_level_constants(completer):
+    completed_attributes = _get_all_completions(completer, "with_dir.")
+    assert set(completed_attributes) == set([
+        "with_dir.CLASS_LEVEL_CONSTANT",
+        "with_dir.a",
+    ])
+
+
+def test_completer_on_object_with_custom_dir_and_hidden_class_level_attributes_returns_only_dir_attributes(completer):
+    completed_attributes = _get_all_completions(completer, "with_dir_and_hide_class.")
+    assert set(completed_attributes) == set([
+        "with_dir_and_hide_class.a",
+    ])

--- a/tests/live/test_completer.py
+++ b/tests/live/test_completer.py
@@ -106,3 +106,8 @@ def test_completer_on_object_with_custom_dir_and_hidden_class_level_attributes_r
     assert set(completed_attributes) == set([
         "with_dir_and_hide_class.a",
     ])
+
+
+def test_completer_with_double_underscore_on_hidden_class_level_attributes_also_offers_dunder_class(completer):
+    completed_attributes = _get_all_completions(completer, "with_dir_and_hide_class._")
+    assert "with_dir_and_hide_class.__class__(" in completed_attributes


### PR DESCRIPTION
The purpose is to let `__dir__()` be the only source of attributes which auto-complete can see.

This matches the auto-complete behavior of IPython.

The lookup of class-level attributes can be disabled by setting an optional flag on the object called  `_AUTO_COMPLETE_HIDE_CLASS_ATTRIBUTES`.