### PR TITLE
Feature: Add first support for Python 3.11, PySide6 6.4

### DIFF
--- a/gdesk/graphics/plotview.py
+++ b/gdesk/graphics/plotview.py
@@ -34,7 +34,7 @@ class PlotView(QtWidgets.QGraphicsView):
 
         # There is the experimental options of using OpenGl
         self.useOpenGL(False)
-        self.setCacheMode(self.CacheBackground)
+        self.setCacheMode(self.CacheModeFlag.CacheBackground)
         self.setBackground(background)
         
         self.setFocusPolicy(QtCore.Qt.StrongFocus)

--- a/gdesk/graphics/view.py
+++ b/gdesk/graphics/view.py
@@ -21,7 +21,7 @@ class SceneView(QtWidgets.QGraphicsView):
         
         #self.useOpenGL(True)
         
-        self.setCacheMode(self.CacheBackground)
+        self.setCacheMode(self.CacheModeFlag.CacheBackground)
         
         self.scale = [1, 1]
         self.center = [0, 0]

--- a/gdesk/panels/console/consolepanel.py
+++ b/gdesk/panels/console/consolepanel.py
@@ -253,7 +253,7 @@ class StdInputPanel(QPlainTextEdit):
         if self.cursor.block().blockNumber() != (self.blockCount() - 1):
             return False
 
-        self.cursor.movePosition(self.cursor.EndOfLine, self.cursor.KeepAnchor)
+        self.cursor.movePosition(QTextCursor.EndOfLine, self.cursor.KeepAnchor)
         curdocpos = self.cursor.position()
         self.cursor.movePosition(self.cursor.StartOfLine, self.cursor.KeepAnchor)
         startlinepos = self.cursor.position()
@@ -583,7 +583,7 @@ class StdPlainOutputPanel(QPlainTextEdit):
                         cursor.PreviousCharacter, cursor.KeepAnchor)
 
                 elif act.action == 'newline':
-                    cursor.movePosition(cursor.EndOfLine)
+                    cursor.movePosition(QTextCursor.EndOfLine)
                     
                 elif act.action == 'set-title':
                     self.panel.long_title = act.title

--- a/gdesk/panels/console/consolepanel.py
+++ b/gdesk/panels/console/consolepanel.py
@@ -291,7 +291,7 @@ class StdInputPanel(QPlainTextEdit):
 
     def moveCursorToEndOfDoc(self):
         cursor=self.textCursor()
-        cursor.movePosition(cursor.End)
+        cursor.movePosition(QTextCursor.End)
         self.setTextCursor(cursor)
 
     def execute_commands(self, cmd=None):

--- a/gdesk/panels/console/consolepanel.py
+++ b/gdesk/panels/console/consolepanel.py
@@ -133,7 +133,7 @@ class LineNumberArea(QWidget):
                 if not cursor.block().next().isValid():
                     break
 
-                cursor.movePosition(cursor.NextBlock)
+                cursor.movePosition(QTextCursor.NextBlock)
         finally:
             painter.end()
 
@@ -253,9 +253,9 @@ class StdInputPanel(QPlainTextEdit):
         if self.cursor.block().blockNumber() != (self.blockCount() - 1):
             return False
 
-        self.cursor.movePosition(QTextCursor.EndOfLine, self.cursor.KeepAnchor)
+        self.cursor.movePosition(QTextCursor.EndOfLine, QTextCursor.KeepAnchor)
         curdocpos = self.cursor.position()
-        self.cursor.movePosition(self.cursor.StartOfLine, self.cursor.KeepAnchor)
+        self.cursor.movePosition(QTextCursor.StartOfLine, QTextCursor.KeepAnchor)
         startlinepos = self.cursor.position()
 
         return curdocpos == startlinepos
@@ -573,14 +573,14 @@ class StdPlainOutputPanel(QPlainTextEdit):
 
                 elif act.action == 'carriage-return':
                     cursor.movePosition(
-                        cursor.StartOfLine, cursor.KeepAnchor)
+                        QTextCursor.StartOfLine, QTextCursor.KeepAnchor)
 
                 elif act.action == 'beep':
                     gui.qapp.beep()
 
                 elif act.action == 'backspace':
                     cursor.movePosition(
-                        cursor.PreviousCharacter, cursor.KeepAnchor)
+                        QTextCursor.PreviousCharacter, QTextCursor.KeepAnchor)
 
                 elif act.action == 'newline':
                     cursor.movePosition(QTextCursor.EndOfLine)
@@ -612,8 +612,8 @@ class StdPlainOutputPanel(QPlainTextEdit):
                 else:
                     old_text = selection[len(substring):]
                     cursor.insertText(substring + old_text, format)
-                    cursor.movePosition(cursor.PreviousCharacter,
-                           cursor.KeepAnchor, len(old_text))
+                    cursor.movePosition(QTextCursor.PreviousCharacter,
+                           QTextCursor.KeepAnchor, len(old_text))
 
         cursor.setBlockCharFormat(QTextCharFormat())
         cursor.endEditBlock()

--- a/gdesk/panels/console/consolepanel.py
+++ b/gdesk/panels/console/consolepanel.py
@@ -286,7 +286,7 @@ class StdInputPanel(QPlainTextEdit):
 
     def moveCursorToEndOfBlock(self):
         cursor=self.textCursor()
-        cursor.movePosition(cursor.EndOfBlock)
+        cursor.movePosition(QTextCursor.EndOfBlock)
         self.setTextCursor(cursor)
 
     def moveCursorToEndOfDoc(self):

--- a/gdesk/panels/imgview/imgview.py
+++ b/gdesk/panels/imgview/imgview.py
@@ -859,7 +859,7 @@ class ImageViewerWidget(QWidget):
 
         else:
             if config["image"].get('render_detail_smooth', False) and self.zoomDisplay < 1:
-                qp.setRenderHint(qp.SmoothPixmapTransform)
+                qp.setRenderHint(qp.RenderHint.SmoothPixmapTransform)
 
             qp.scale(self.zoomDisplay, self.zoomDisplay)
             qp.translate(-sx, -sy)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ REQUIRED = [
     'scipy',
     'qtpy',
     'psutil',
-    'numba',
+    # Numba is not yet released for Python 3.11.
+    # See https://github.com/numba/numba/issues/8304
+    'numba;python_version<"3.11"',
     'pyzmq',
     'pywinpty; sys_platform=="win32"',
 ]


### PR DESCRIPTION
Python 3.11 is interesting because it's much faster than previous releases.

The only dependency which is not yet on 3.11 is `numba`, whose 3.11 support will take a while to emerge.

This is not fully tested, but allows gdesk to start up at least.

Some of the fixes are related to PySide 6.4 support.