### PR TITLE
Use uv as project management tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 __pycache__/
 gdesk/stderr.log
 .idea/
+uv.lock

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+
+vNext
+-----
+date: TBD
+
+- Do project management with ``uv``.
+- Expose detailed (parsed) version information (``packaging.version.Version``)
+
+Do note the version semantics have changed:
+
+* ``VERSION_INFO`` does no longer exist.
+* ``__version__`` is now a string.
+* Access ``__version_info__`` for detailed version attributes.
+
+
 v1.6.3
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,10 +49,10 @@ date: 2024-12-13
 - Fix getcodefile for script files
 - fix enforce ymin to 0 for all scaling modes except for log+cum
 - Cycle through y-scales on button press
-- Remove roi switch, draw histrograms based on active statistics
+- Remove roi switch, draw histograms based on active statistics
 - Add multi mask selection on profiles and histogram
 - Reduce keyboard capture to 2 sec
-- SURPRISE, floor division is faster then bitshift! (a x86 thing)
+- SURPRISE, floor division is faster than bitshift! (a x86 thing)
 - Enforcing parallel execution seems to only stress the PC to 100% CPU, but very little gain in performance
 - Tryout auto completion on input (on the 1 level higher workspace)
 - Show the top of the html page on show
@@ -60,7 +60,7 @@ date: 2024-12-13
 - Prepare for window variant of the textbrowser dialog
 - The ask_refresh flow (request and acknowledge) was lagging
 - ask_refresh was not set to 0 if no update was needed.
-- But beacause of this, there was also no mark_for_update needed for next time.
+- But because of this, there was also no mark_for_update needed for next time.
 - Which was also not done.
 - Split markUpdateCall into markUpdateCallTop and markUpdateCallNest
 - Use an Enum for the Update Flags
@@ -98,7 +98,7 @@ date: 2024-11-14
 - Fix error on loading new panel layout
 - Add context menu to statistics panel to choose columns
 - Add call_func_ext as extension on call_func to call a function on another thread of process with kwargs
-- Extend the funcitonality on default dir and file for formlayout get and set file/dir dialog
+- Extend the functionality on default dir and file for formlayout get and set file/dir dialog
 - Fix cancel of Choose statistic dialog and add stat dependent formatting
 - Fix some ndim = 3 behavior combined with bayer pattern
 - Add callbackexcept to wrap around a callback to capture errors from other thread or process
@@ -131,7 +131,7 @@ date: 2024-11-14
 - This is needed to make it readable in the dark mode and should not affect the light mode
 - dev: Force black text on light background labels
 - Otherwise, in dark mode the white text won't be readable
-- dev: Expand range of allowed matplotlibs
+- dev: Expand range of allowed matplotlib versions
 - doc(minor): Add some type hints
 - fix(36): Avoid crash with matplotlib/PySide6/Linux
 - Don't interfere with buffer ref count.
@@ -144,17 +144,17 @@ date: 2024-11-14
 - Add 20, 22 and 24 bit scales in levels
 - Make a group of 3 button for y scale: lin, log, and 1
 - Extend the statistcs/roi toolbar
-- Add checbox icons
+- Add checkbox icons
 - Use check_boxes icon
 - Fix docking button for StatsDock
-- Move the ImageViewerWidget object to seperate file
+- Move the ImageViewerWidget object to separate file
 - Add gui.img.is_roi_selected()
-- Add icons for rgb and monochroom masks selection
+- Add icons for rgb and monochrome masks selection
 - Add mask selection button to statspanel
-- Add option for cummulative histogram
+- Add option for cumulative histogram
 - Use inverse error function scaling for log+norm levels scaling
 - Remove commented out code
-- Move imgview status bar to seperate file
+- Move imgview status bar to separate file
 - Don't freeze y or enforce fixed y 0 when moving the plot if log and cumulative
 - Remove auto show of roi selection, use double click or menu item
 - Add refresh after adding new roi
@@ -179,11 +179,12 @@ date: 2024-11-14
 - rename setWaitCursor to setBusyCursor and use BusyCursor
 - Add button in statpanel to cycle through show onyl roi/hide roi or show  all
 - Add button in level panel to cycle through show onyl roi/hide roi or show  all
-- Tollerate a selected rows on the now empty table
+- Tolerate a selected rows on the now empty table
 - Use an eye icon for the show/hide/all roi menu
 - Don't redefine the chanstat everything, but only update the needed items
 - Remove some roi icons
 - Still overwrite all predefined mask def by default
+- Support Python 3.13
 
 
 v1.4.0
@@ -202,7 +203,7 @@ date: 2024-09-27
 - Add the different bayer configs for profiles
 - add cfa parameter
 - Add Data split menu
-- Use same mask definitions for historgram and profiles
+- Use same mask definitions for histogram and profiles
 - Add set_cfa to viewer proxy
 - Fix mask definition error
 - Add and use roi.color item to masks
@@ -243,7 +244,7 @@ date: 2024-09-27
 - Remove fullImageVisible on profiles
 - Fix z values for histograms
 - Add isCleared on chanstat
-- Use prefered order of the masks
+- Use preferred order of the masks
 - Show the roi with the selection widget
 
 
@@ -379,7 +380,7 @@ date: 2022-01-04
  
 - Add operation menu
 - Add opencv menu
-- Split image viewier status panel into multiple panels
+- Split image viewer status panel into multiple panels
 - Customizable panel size at init
 - Improved panel resize behavior of histograms and profiles
 - Add test image
@@ -470,5 +471,3 @@ v0.0.1
 date: 2021-03-22
 
 - First release
-
- 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,41 @@
+
+# Package compatibility
+
+
+## Windows
+ 
+We use a compiled version of `pywinpty`; otherwise you'd need a Rust compiler.
+
+Since `PyWinPty` dropped Python 3.8 support in `v2.0.15`, we stay below that version on 3.8.
+
+
+## Matplotlib
+
+Avoid MatPlotLib 3.5.2: because it crashes plotting on PySide6.
+
+
+## PySide6
+
+PySide 6.8.0 has a bug which breaks qtpy; avoid that specific release.
+
+
+## Numpy
+
+Numpy v2 introduces some different behavior w.r.t. clipping.
+
+Also, all PySide6 releases before v6.8 choke on numpy 2.x.
+
+We try to avoid numpy v2, but that is only possible up to Python v3.12.
+
+3.12 also misses `distutils`, which is inconvenient for numpy installing.
+
+To avoid the most problems, starting from Python 3.12, we move to numpy v2 and require PySide6 v6.8.
+
+
+## PySide2
+
+Using `pyside2` instead of `pyside6` is possible only up to Python 3.10.
+
+For this reason, PySide6 is preferred for new installs.
+
+To use `pyside2`, install with `--no-deps` and install dependencies manually.

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,21 @@
+
+# Gamma Desk development
+
+Project management is handled with 'uv'.
+
+This means no explicit 'installation' is necessary for development.
+
+
+## Version bump
+
+Edit `version` in the `[project]` section of `pyproject.toml`.
+
+
+## Package
+
+    uv build
+
+
+## Run
+
+    uv run --python 3.13 gdesk

--- a/bat/build.bat
+++ b/bat/build.bat
@@ -1,3 +1,3 @@
 cd ..
-py -3.8 -m build
+uv build
 pause

--- a/bat/build_wheel.bat
+++ b/bat/build_wheel.bat
@@ -1,4 +1,4 @@
 cd ..
-py -3.8 setup.py clean --all
-py -3.8 setup.py bdist_wheel
+uv build --sdist
+uv build --wheel
 pause

--- a/bat/dos.bat
+++ b/bat/dos.bat
@@ -1,2 +1,3 @@
+:: Start new DOS cmd.exe process in the root.
 cd ..
 cmd

--- a/bat/start.bat
+++ b/bat/start.bat
@@ -1,4 +1,6 @@
 cd ..
-python -m gdesk
-REM python -m gdesk -c ./test/gdconf.json
+uv run python -m gdesk
+:: To run with test procedure or experimental config file:
+:: uv run python -m gdesk -i ./test/setup/test_gdesk.py
+:: uv run python -m gdesk -c ./test/gdconf.json
 pause

--- a/bat/start_gui_as_child.bat
+++ b/bat/start_gui_as_child.bat
@@ -1,4 +1,3 @@
 cd ..
-SET PYTHONPATH=%~dp0\..
-python -i ./test/start_gdesk_as_child.py
+uv run python -i ./test/start_gdesk_as_child.py
 pause

--- a/bat/start_py.bat
+++ b/bat/start_py.bat
@@ -1,0 +1,40 @@
+:: Start GDesk with a Python version supplied as first argument
+::   on the command line.
+:: If the second argument is 'test' then execute a self-test procedure.
+:: Example:
+:: start_py.bat 3.13 test
+@echo OFF
+
+set PYTHON_VERSION=%1
+set TEST=%2
+
+IF [%PYTHON_VERSION%] == [] GOTO NOT_SUPPLIED
+
+FOR %%G IN ("3.8"
+            "3.9"
+            "3.10"
+            "3.11"
+            "3.12"
+            "3.13"
+            ) DO (
+            IF /I "%PYTHON_VERSION%"=="%%~G" GOTO SUPPORTED
+)
+
+:NOT_SUPPLIED
+echo Python version is not given; supply as first argument (e.g.: 3.13).
+pause
+GOTO :EOF
+
+:NOT_SUPPORTED
+echo Python version is not supported: '%PYTHON_VERSION%'
+pause
+GOTO :EOF
+
+:SUPPORTED
+cd ..
+if /I "%TEST%" == "test" (
+    uv run --python %PYTHON_VERSION% python -m gdesk -i .\test\setup\test_gdesk.py
+) else (
+    uv run --python %PYTHON_VERSION% python -m gdesk
+)
+GOTO :EOF

--- a/bat/start_py310.bat
+++ b/bat/start_py310.bat
@@ -1,0 +1,5 @@
+cd ..
+uv run --python 3.10 python -m gdesk
+:: uv run --python 3.10 python -m gdesk -c ./test/gdconf.json
+:: uv run --python 3.10 python -m gdesk -i ./test/setup/test_gdesk.py
+pause

--- a/bat/start_py311.bat
+++ b/bat/start_py311.bat
@@ -1,0 +1,5 @@
+cd ..
+uv run --python 3.11 python -m gdesk
+:: uv run --python 3.11 python -m gdesk -c ./test/gdconf.json
+:: uv run --python 3.11 python -m gdesk -i ./test/setup/test_gdesk.py
+pause

--- a/bat/start_py312.bat
+++ b/bat/start_py312.bat
@@ -1,0 +1,5 @@
+cd ..
+uv run --python 3.12 python -m gdesk
+:: uv run --python 3.12 python -m gdesk -c ./test/gdconf.json
+:: uv run --python 3.12 python -m gdesk -i ./test/setup/test_gdesk.py
+pause

--- a/bat/start_py313.bat
+++ b/bat/start_py313.bat
@@ -1,0 +1,4 @@
+uv run --python 3.13 python -m gdesk
+:: uv run --python 3.13 python -m gdesk -c ./test/gdconf.json
+:: uv run --python 3.13 python -m gdesk -i ./test/setup/test_gdesk.py
+pause

--- a/bat/start_py36.bat
+++ b/bat/start_py36.bat
@@ -1,4 +1,0 @@
-cd ..
-py -3.6 -m gdesk
-REM python -m gdesk -c ./test/gdconf.json
-pause

--- a/bat/start_py38.bat
+++ b/bat/start_py38.bat
@@ -1,4 +1,5 @@
 cd ..
-py -3.8 -m gdesk
-REM python -m gdesk -c ./test/gdconf.json
+uv run --python 3.8 python -m gdesk
+:: uv run --python 3.8 python -m gdesk -c ./test/gdconf.json
+:: uv run --python 3.8 python -m gdesk -i ./test/setup/test_gdesk.py
 pause

--- a/bat/start_py39.bat
+++ b/bat/start_py39.bat
@@ -1,4 +1,5 @@
 cd ..
-py -3.9 -m gdesk
-REM python -m gdesk -c ./test/gdconf.json
+uv run --python 3.9 python -m gdesk
+:: uv run --python 3.9 python -m gdesk -c ./test/gdconf.json
+:: uv run --python 3.9 python -m gdesk -i ./test/setup/test_gdesk.py
 pause

--- a/bat/start_test.bat
+++ b/bat/start_test.bat
@@ -1,3 +1,3 @@
 cd ..
-python -m gdesk -i ./test/setup/test_gdesk.py
+uv run python -m gdesk -i .\test\setup\test_gdesk.py
 pause

--- a/bat/upload_real.bat
+++ b/bat/upload_real.bat
@@ -1,4 +1,8 @@
 REM token in $HOME/.pypirc
 cd ..
 py -3.8 -m twine upload --repository pypi --verbose dist/*1.6.0-*
+
+:: Note: alternative using UV, requires custom configuration.
+:: See https://docs.astral.sh/uv/guides/package/#publishing-your-package
+:: uv publish --index pypi
 pause

--- a/gdesk/__init__.py
+++ b/gdesk/__init__.py
@@ -17,7 +17,7 @@
 """Gamma Desk"""
 
 import sys
-from .version import VERSION_INFO
+from .version import __version__, __version_info__
 from .core.conf import config, configure
 
 #from .core.gui_proxy import gui
@@ -29,8 +29,7 @@ PROGNAME = 'Gamma Desk'
 DOC_HTML = 'https://thocoo.github.io/gdesk-data/docs'
 DOC_HTML_EXTRA = ['https://test.pypi.org/project/gamma-desk']
 
-__release__ = "-".join(map(str, VERSION_INFO)).replace("-", ".", 2)
-__version__ = ".".join(map(str, VERSION_INFO[:3]))
+__release__ = __version__
 
 shell = None
 

--- a/gdesk/matplotbe/__init__.py
+++ b/gdesk/matplotbe/__init__.py
@@ -30,7 +30,7 @@ from .. import gui
 if not version.parse('3.2') <= version.parse(matplotlib.__version__) < version.parse('3.10'):
     warnings.warn(
         f'Matplotlib version {matplotlib.__version__} not supported.\n'
-        f'Version should be 3.2 to 3.10'
+        f'Version should be 3.2 to 3.11'
     )
         
 if config.get('qapp'):

--- a/gdesk/matplotbe/__init__.py
+++ b/gdesk/matplotbe/__init__.py
@@ -11,9 +11,8 @@ import ctypes
 import threading
 import logging
 import warnings
-from distutils.version import LooseVersion
-
 import matplotlib
+
 from matplotlib.transforms import Bbox
 from matplotlib.figure import Figure
 from matplotlib import cbook
@@ -21,14 +20,14 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import FigureCanvasBase, FigureManagerBase
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.backends.backend_qt5 import FigureCanvasQT
-  
 from matplotlib.backends.qt_compat import QT_API
 from matplotlib import rcParams
+from packaging import version
 
 from .. import gui
 
 
-if not LooseVersion('3.2') <= LooseVersion(matplotlib.__version__) < LooseVersion('3.10'):
+if not version.parse('3.2') <= version.parse(matplotlib.__version__) < version.parse('3.10'):
     warnings.warn(
         f'Matplotlib version {matplotlib.__version__} not supported.\n'
         f'Version should be 3.2 to 3.10'
@@ -38,21 +37,21 @@ if config.get('qapp'):
     from qtpy import QtCore, QtGui
     from ..panels.matplot import PlotPanel        
 
-    if LooseVersion(matplotlib.__version__) == LooseVersion('3.2'):
+    if version.parse(matplotlib.__version__) == version.parse('3.2'):
         setDevicePixelRatio = QtGui.QImage.setDevicePixelRatio
         DEV_PIXEL_RATIO_ATTR = "_dpi_ratio"    
         
-    elif LooseVersion(matplotlib.__version__) == LooseVersion('3.3'):
+    elif version.parse(matplotlib.__version__) == version.parse('3.3'):
         from matplotlib.backends.qt_compat import _setDevicePixelRatioF
         setDevicePixelRatio = _setDevicePixelRatioF
         DEV_PIXEL_RATIO_ATTR = "_dpi_ratio"
         
-    elif LooseVersion(matplotlib.__version__) < LooseVersion('3.5'):
+    elif version.parse(matplotlib.__version__) < version.parse('3.5'):
         from matplotlib.backends.qt_compat import _setDevicePixelRatio
         setDevicePixelRatio = _setDevicePixelRatio
         DEV_PIXEL_RATIO_ATTR = "_dpi_ratio"
         
-    elif LooseVersion(matplotlib.__version__) == LooseVersion('3.5'):
+    elif version.parse(matplotlib.__version__) == version.parse('3.5'):
         from matplotlib.backends.qt_compat import _setDevicePixelRatio
         setDevicePixelRatio = _setDevicePixelRatio
         DEV_PIXEL_RATIO_ATTR = "_device_pixel_ratio"       

--- a/gdesk/matplotbe/__init__.py
+++ b/gdesk/matplotbe/__init__.py
@@ -35,23 +35,25 @@ if not version.parse('3.2') <= version.parse(matplotlib.__version__) < version.p
         
 if config.get('qapp'):
     from qtpy import QtCore, QtGui
-    from ..panels.matplot import PlotPanel        
+    from ..panels.matplot import PlotPanel
 
-    if version.parse(matplotlib.__version__) == version.parse('3.2'):
+    matplot_version = version.parse(matplotlib.__version__)
+
+    if matplot_version == version.parse('3.2'):
         setDevicePixelRatio = QtGui.QImage.setDevicePixelRatio
         DEV_PIXEL_RATIO_ATTR = "_dpi_ratio"    
         
-    elif version.parse(matplotlib.__version__) == version.parse('3.3'):
+    elif matplot_version == version.parse('3.3'):
         from matplotlib.backends.qt_compat import _setDevicePixelRatioF
         setDevicePixelRatio = _setDevicePixelRatioF
         DEV_PIXEL_RATIO_ATTR = "_dpi_ratio"
         
-    elif version.parse(matplotlib.__version__) < version.parse('3.5'):
+    elif matplot_version < version.parse('3.5'):
         from matplotlib.backends.qt_compat import _setDevicePixelRatio
         setDevicePixelRatio = _setDevicePixelRatio
         DEV_PIXEL_RATIO_ATTR = "_dpi_ratio"
         
-    elif version.parse(matplotlib.__version__) == version.parse('3.5'):
+    elif matplot_version == version.parse('3.5'):
         from matplotlib.backends.qt_compat import _setDevicePixelRatio
         setDevicePixelRatio = _setDevicePixelRatio
         DEV_PIXEL_RATIO_ATTR = "_device_pixel_ratio"       

--- a/gdesk/test/__init__.py
+++ b/gdesk/test/__init__.py
@@ -254,6 +254,8 @@ class GammaDeskSuite(unittest.TestCase):
                  r"| |_\ \| (_| || | | | | || | | | | || (_| | | |/ / |  __/\__ \|   < " + "\n" \
                  r" \____/ \__,_||_| |_| |_||_| |_| |_| \__,_| |___/   \___||___/|_|\_" + "\\"
 
+        print("")
+
         fgs = [227, 227, 222, 217, 212, 207]
         for fg, line in zip(fgs, banner.splitlines()):
             bg = 236

--- a/gdesk/test/__init__.py
+++ b/gdesk/test/__init__.py
@@ -1,5 +1,12 @@
 import unittest
 
+from packaging import version
+import numpy
+
+
+NUMPY_V1 = version.parse(numpy.__version__) < version.parse("2")
+
+
 class GammaDeskSuite(unittest.TestCase):
     panid = 1
 
@@ -87,7 +94,7 @@ class GammaDeskSuite(unittest.TestCase):
         self.assertEqual(gui.vs.min(), 0.5)
         self.assertEqual(gui.vs.max(), 0.5)
 
-        #https://imageio.readthedocs.io/en/stable/standardimages.html
+        # https://imageio.readthedocs.io/en/stable/standardimages.html
         gui.img.menu(['File', 'Open Image...'], 'imageio:astronaut.png')
         gui.img.menu(['File', 'Open Image...'], 'imageio:wood.jpg')
         gui.img.menu(['File', 'Open Image...'], 'imageio:camera.png')
@@ -173,7 +180,7 @@ class GammaDeskSuite(unittest.TestCase):
         from gdesk import gui
         import imageio
 
-        arr = imageio.imread('imageio:astronaut.png')
+        arr = imageio.v2.imread('imageio:astronaut.png')
 
         gui.load_layout('image, levels & console')
         gui.img.select(1)
@@ -181,11 +188,17 @@ class GammaDeskSuite(unittest.TestCase):
         gui.img.zoom_full()
         gui.menu_trigger('image', imgpanid, ['Image', 'Invert'])
         gui.menu_trigger('image', imgpanid, ['Image', 'Swap RGB | BGR'])
-        gui.menu_trigger('image', imgpanid, ['Image', 'Adjust Lighting...'], 255, -1)
+
+        if NUMPY_V1:
+            gui.menu_trigger('image', imgpanid, ['Image', 'Adjust Lighting...'], 255, -1)
+        else:
+            # Numpy v2 chokes on the * 255 -1 because it clips.
+            # (OverflowError: Python integer -1 out of bounds for uint8)
+            # Instead, invert back
+            gui.menu_trigger('image', imgpanid, ['Image', 'Invert'])
+
         gui.menu_trigger('image', imgpanid, ['Image', 'Swap RGB | BGR'])
-
         assert (arr == gui.vs).all()
-
 
     def test_menu_image_2(self):
         from gdesk import gui

--- a/gdesk/test/__init__.py
+++ b/gdesk/test/__init__.py
@@ -54,7 +54,9 @@ class GammaDeskSuite(unittest.TestCase):
             line = f'i = {i}'
             print(line)
             expectedOutput += f'{line}\n'
-            time.sleep(0.01)
+            time.sleep(0.05)
+
+        time.sleep(0.1)
 
         sys.stdout.flush()
         text = gui.console.text()

--- a/gdesk/test/__init__.py
+++ b/gdesk/test/__init__.py
@@ -51,7 +51,7 @@ class GammaDeskSuite(unittest.TestCase):
 
         sys.stdout.flush()
         text = gui.console.text()
-        assert expectedOutput == text
+        assert expectedOutput == text, f"'{text}' != '{expectedOutput}'"
 
 
     def test_menu_file(self):

--- a/gdesk/test/__init__.py
+++ b/gdesk/test/__init__.py
@@ -98,8 +98,13 @@ class GammaDeskSuite(unittest.TestCase):
     def test_menu_canvas(self):
         from gdesk import gui
         import scipy.misc
-
-        arr = scipy.misc.face()
+        
+        if hasattr(scipy.misc, "face"):
+            arr = scipy.misc.face()
+        else:
+            import scipy.datasets
+            arr = scipy.datasets.face()
+        
         height, width = arr.shape[:2]
 
         gui.load_layout('image, levels & console')

--- a/gdesk/version.py
+++ b/gdesk/version.py
@@ -1,4 +1,8 @@
+
 """Version details of Gamma Desk"""
 
-VERSION_INFO = (1, 6, 3)
-VERSION = '.'.join(str(v) for v in VERSION_INFO)
+from importlib.metadata import version
+from packaging.version import parse
+
+__version__ = version("gamma-desk")
+__version_info__ = parse(__version__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "pyzmq",
     "pywinpty; sys_platform=='win32'",
     "legacy-cgi; python_version > '3.12'",
+    "packaging",
     # Note: pyside2 should also work; to use it install with `--no-deps` and install
     # dependencies manually.
     "pyside6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "gamma-desk"
 version = "1.6.4.dev0"
 description = "A Python work environment with image viewers & plots"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 authors = [
     {name = "Thomas Cools", email = "thomas.cools@telenet.be"},
 ]
@@ -22,8 +22,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,65 @@
+
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+
+[tool.flit.module]
+name = "gdesk"
+
+
+[project]
+name = "gamma-desk"
+version = "1.6.4.dev0"
+description = "A Python work environment with image viewers & plots"
+readme = "README.md"
+requires-python = ">=3.6"
+authors = [
+    {name = "Thomas Cools", email = "thomas.cools@telenet.be"},
 ]
-build-backend = "setuptools.build_meta"
+classifiers = [
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+    "numpy",
+    "pillow",
+    "imageio",
+    "imageio-ffmpeg",
+    # Exclude MatPlotLib 3.5.2 because it crashes plotting on PySide6.
+    "matplotlib != 3.5.2",
+    "scipy",
+    "qtpy",
+    "psutil",
+    "numba",
+    "pyzmq",
+    "pywinpty; sys_platform=='win32'",
+    "legacy-cgi; python_version > '3.12'",
+]
+
+
+[project.optional-dependencies]
+pyside2 = ["pyside2"]
+pyside6 = ["pyside2"]
+all = ["pyside6"]
+
+
+[project.scripts]
+gdesk = "gdesk.console:argexec"
+
+
+[project.urls]
+Source = "https://github.com/thocoo/gamma-desk"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ gdesk = "gdesk.console:argexec"
 [project.urls]
 Source = "https://github.com/thocoo/gamma-desk"
 
+[dependency-groups]
+dev = [
+    # Required by scipy for downloading datasets (used in test).
+	# Older scipy versions had the dataset built-in.
+    "pooch; python_version>='3.9'",
+]
+
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,25 +30,28 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "numpy",
     "pillow",
     "imageio",
-    "imageio-ffmpeg",
-    # Exclude MatPlotLib 3.5.2 because it crashes plotting on PySide6.
-    "matplotlib != 3.5.2",
+    "imageio-ffmpeg",	
     "scipy",
     "qtpy",
     "psutil",
     "numba",
-    "pyzmq",
-    "pywinpty; sys_platform=='win32'",
-    "legacy-cgi; python_version > '3.12'",
+    "pyzmq",	
     "packaging",
-    # Note: pyside2 should also work; to use it install with `--no-deps` and install
-    # dependencies manually.
-    "pyside6",
-]
+	
+	# Some more 'fun' dependencies, see COMPATIBILITY.md.
 
+    "matplotlib != 3.5.2",
+    "legacy-cgi; python_version > '3.12'",
+    "pywinpty<2.0.15; sys_platform=='win32' and python_version<='3.8'",
+    "pywinpty; sys_platform=='win32' and python_version>'3.8'",
+    "pyside6; python_version<'3.12'",
+    "pyside6>=6.8.1; python_version>='3.12'",
+    "numpy<2; python_version<'3.12'",
+    "numpy>=2; python_version>='3.12'",
+]
+ 
 
 [project.scripts]
 gdesk = "gdesk.console:argexec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,10 @@ dependencies = [
     "pyzmq",
     "pywinpty; sys_platform=='win32'",
     "legacy-cgi; python_version > '3.12'",
+    # Note: pyside2 should also work; to use it install with `--no-deps` and install
+    # dependencies manually.
+    "pyside6",
 ]
-
-
-[project.optional-dependencies]
-pyside2 = ["pyside2"]
-pyside6 = ["pyside2"]
-all = ["pyside6"]
 
 
 [project.scripts]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ REQUIRED = [
     'psutil',
     'numba',
     'pyzmq',
+    'packaging',
     'pywinpty; sys_platform=="win32"',
     'legacy-cgi; python_version > "3.12"',
 ]


### PR DESCRIPTION
Major changes:

* Use `uv` instead of manual virtualenvs
* Drop Python versions < 3.8
* Start using `nympy` v2 starting from Python 3.12.
* Default to PySide6 (PySide2 only possible when installing with `--no-deps`)
* Use `packaging.version` to lookup gdesk's own `__version__` string, parse it into `__version_info__`.