### PR TITLE
fix: Set 'opens_with' attribute of NdimGuiProxy

### DIFF
--- a/gdesk/panels/ndim/proxy.py
+++ b/gdesk/panels/ndim/proxy.py
@@ -8,7 +8,7 @@ from ... import gui
 
 class NdimGuiProxy(GuiProxyBase):
     category = 'ndim'
-    # opens_with = ['.tif', '.png', '.gif']
+    opens_with = ['.h5', '.hdf5', '.he5', '.gif', '.npz', '.mov', '.mp4']
 
     def __init__(self):
         pass


### PR DESCRIPTION
This allows the generic "File -> Open File" action from the console panel to open multidimensional data like hdf5 and npz files

Closes #46 