### PR TITLE
Execute GDESKSTARTUP Python file at startup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ vNext
 -----
 date: TBD
 
+- Support GDESKSTARTUP environment variable; execute that file when configured.
 - Do project management with ``uv``.
 - Expose detailed (parsed) version information (``packaging.version.Version``)
 

--- a/gdesk/gcore/guiapp.py
+++ b/gdesk/gcore/guiapp.py
@@ -3,11 +3,11 @@ import sys, os
 import ctypes
 import logging
 import textwrap
-import pathlib
 import mmap
 import struct
 import threading
 import psutil
+from pathlib import Path
 
 from qtpy import QtGui, QtWidgets, QtCore, API_NAME
 from qtpy.QtWidgets import QApplication, QShortcut
@@ -44,8 +44,8 @@ from ..panels.base import thisPanel
 
 from ..dialogs.main import MainDialog
 
-here = pathlib.Path(__file__).parent
-respath = pathlib.Path(config['respath'])
+here = Path(__file__).parent
+respath = Path(config['respath'])
 logger = logging.getLogger(__name__)
 
 
@@ -153,7 +153,7 @@ class GuiApplication(QApplication):
             
             if scale != 1.0:
                 logger.warning('Screen scale in application is not 1 !!!')
-                logger.warning('Scaling on PySide6 can be disabled by environmental variable')
+                logger.warning('Scaling on PySide6 can be disabled by environment variable')
                 logger.warning('QT_ENABLE_HIGHDPI_SCALING= 0')                            
             
 
@@ -379,6 +379,12 @@ def eventloop(shell, init_code=None, init_file=None, console_id=0, pictures=None
         cmd = {'cmd': 'execute_code', 'args': (init_code, console_id)}
         qapp.cmdserver.cmd_queue.put(cmd)        
         
+    gdesk_startup = os.environ.get("GDESKSTARTUP")
+    if gdesk_startup and Path(gdesk_startup).exists():
+        print(f"Executing GDESKSTARTUP: '{gdesk_startup}'")
+        cmd = {'cmd': 'execute_file', 'args': (gdesk_startup, console_id)}
+        qapp.cmdserver.cmd_queue.put(cmd)        
+
     if not pictures is None:
         cmd = {'cmd': 'open_images', 'args': pictures}
         qapp.cmdserver.cmd_queue.put(cmd)            


### PR DESCRIPTION
This can automatically load often-used imports like Path, numpy, pyplot, ...

Fixes #48.