### PR TITLE
Support loading an xarray.DataArray in the ndim panel

### DIFF
--- a/gdesk/config/defaults.json
+++ b/gdesk/config/defaults.json
@@ -128,7 +128,9 @@
       "prefix": "Ctrl+F",
       "1": "console",
       "2": "image, levels & console",
-      "3": "4 images, 1 levels & 1 console"}},
+      "3": "4 images, 1 levels & 1 console",
+      "4": "image, levels, console & ndim"
+    }},
   "panel_class_modules": [
     "gdesk.panels.dialog",
     "gdesk.panels.console",
@@ -458,6 +460,134 @@
               761,
               761
             ],
+            "type": "layout"
+          },
+          "name": "main",
+          "visible": true
+        },
+        {
+          "docks": {
+            "category": "console",
+            "id": 0,
+            "type": "panel"
+          },
+          "name": "window 1",
+          "visible": false
+        }
+      ]
+    },
+    "image, levels, console & ndim": {
+      "description": "image thread and sub thread with ndim panel",
+      "panels": [
+        {
+          "bindings": [],
+          "category": "console",
+          "id": 0,
+          "module": "gdesk.panels.console.consolepanel",
+          "qualname": "MainThreadConsole",
+          "title": "console#0"
+        },
+        {
+          "bindings": [],
+          "category": "console",
+          "id": 1,
+          "module": "gdesk.panels.console.consolepanel",
+          "qualname": "SubThreadConsole",
+          "title": "console#1"
+        },
+        {
+          "bindings": [
+            {
+              "category": "image",
+              "id": 1
+            }
+          ],
+          "category": "levels",
+          "id": 1,
+          "module": "gdesk.panels.levels.panel",
+          "qualname": "LevelsPanel",
+          "title": "levels#1"
+        },
+        {
+          "bindings": [
+            {
+              "category": "image",
+              "id": 1
+            }
+          ],
+          "category": "ndim",
+          "id": 1,
+          "module": "gdesk.panels.ndim.panel",
+          "qualname": "NdimPanel",
+          "title": "ndim#1"
+        },
+        {
+          "bindings": [
+            {
+              "category": "levels",
+              "id": 1
+            }
+          ],
+          "category": "image",
+          "id": 1,
+          "module": "gdesk.panels.imgview.imgview",
+          "qualname": "ImageProfilePanel",
+          "title": "image#1"
+        }
+      ],
+      "windows": [
+        {
+          "docks": {
+            "category": "hbox",
+            "id": "hbox#1",
+            "items": [
+              {
+                "category": "image",
+                "id": 1,
+                "type": "panel"
+              },
+              {
+                "category": "vbox",
+                "id": "vbox#1",
+                "items": [
+                  {
+                    "category": "levels",
+                    "id": 1,
+                    "type": "panel"
+                  },
+                  {
+                    "type": "panel",
+                    "category": "ndim",
+                    "id": 1
+                  },
+                  {
+                    "category": "console",
+                    "id": 1,
+                    "type": "panel"
+                  }
+                ],
+                "sizes": [
+                  250,
+                  200,
+                  550
+                ],
+                "pinscroll": [
+                  1000,
+                  0
+                ],
+                "scroll": [],
+                "type": "layout"
+              }
+            ],
+            "sizes": [
+              800,
+              800
+            ],
+            "pinscroll": [
+              1600,
+              0
+            ],
+            "scroll": [],
             "type": "layout"
           },
           "name": "main",

--- a/gdesk/panels/ndim/hdf5.py
+++ b/gdesk/panels/ndim/hdf5.py
@@ -11,7 +11,7 @@ def load_ndim_from_hdf5(filepath):
     """Load one multi dim (>2) file from a hdf5 file
 
     If multiple ndim arrays are found then it asks the user which one to load.
-    It throws an ImportError when no dataset when more than 2 dims is found.
+    It throws an ImportError when no dataset with more than 2 dims is found.
 
     :param filepath: pathlib.Path uri to file to load
     :return: ndarray, key_name, list with dim names, list with dim scales (name, scale)

--- a/gdesk/panels/ndim/panel.py
+++ b/gdesk/panels/ndim/panel.py
@@ -51,10 +51,14 @@ class NdimPanel(BasePanel):
 
         self.addBaseMenu(['image'])
         self.statusBar().hide()
+        self._previous_folder = None
 
     def open_dialog(self):
         """Open file selection dialog and open the selected file"""
-        filepath = here.parent.parent / 'resources' / 'ndim' / 'space_cat.npz'
+        if self._previous_folder is not None:
+            filepath = self._previous_folder
+        else:
+            filepath = here.parent.parent / 'resources' / 'ndim' / 'space_cat.npz'
 
         filepath, filter = gui.getfile(title='Open n-dim data or multiple images', file=str(filepath.absolute()),
                                        filter="Supported (*.h5 *.hdf5 *.npz *.gif *.mov *.mp4);;"
@@ -62,6 +66,8 @@ class NdimPanel(BasePanel):
                                               "MP4 (*.mp4);; All (*.*)")
         if filepath == '':
             return
+
+        self._previous_folder = pathlib.Path(filepath).parent
 
         self.open(filepath)
 

--- a/gdesk/panels/ndim/proxy.py
+++ b/gdesk/panels/ndim/proxy.py
@@ -41,8 +41,28 @@ class NdimGuiProxy(GuiProxyBase):
         return panel.panid
 
     @StaticGuiCall
-    def load_data(data, new=False):
-        """Open a new panel if needed and load the data / multidimensional ndarray"""
+    def load_data(data, name=None, dim_names=None, dim_scales=None,  new=False) -> int:
+        """Load a np ndarray or xarray DataArray into an ndim panel, open a new panel if needed
+
+        The DataArray can contain additional annotation such as the names of the dimensions,
+        and coordinate values (setting the `dim_scales` here). There is no need to use
+        dim_names and dim_scales if the data is a xarray DataArray, as this information is
+        already present in the DataArray.
+
+        Three special sliders exist:
+          * Row: treat a dimension as row index.
+          * Col: treat a dimension as column index.
+          * Color: treat a dimension as having RGB or RGBA layers.
+
+        All other dimensions become generic sliders.
+
+        :param data: numpy nd array (or xarray DataArray) with the multi dim data.
+        :param name: optional name of this data, is used when saving to hdf5.
+        :param dim_names: optional list of length ndim with names per dimensions.
+        :param dim_scales: optional list with (name, scale) tuples with scale values for each entry in a dim.
+        :param new: open a new panel if True, otherwise use the current panel if it exists.
+        :return: the panel id of the opened panel.
+        """
         if new:
             NdimGuiProxy.new()
             panel = gui.qapp.panels.selected('ndim')
@@ -51,18 +71,41 @@ class NdimGuiProxy(GuiProxyBase):
             if panel is None:
                 panel = gui.qapp.panels.select_or_new('ndim')
 
-        panel.load(data)
+        panel.load(data=data, name=name, dim_names=dim_names, dim_scales=dim_scales)
         return panel.panid
 
     @StaticGuiCall
-    def update_data(ndarray):
+    def update_data(data):
+        """Update the data in the current panel leaving all the rest as is
+
+        This can be used to update the data when the dimensions are the same, but the data has changed.
+        """
         panel = gui.qapp.panels.selected('ndim')
-        panel.update_data(ndarray)
+        panel.update_data(data)
 
     @StaticGuiCall
-    def get_data():
+    def get_data() -> 'np.ndarray':
+        """Get the data from the current panel"""
         panel = gui.qapp.panels.selected('ndim')
         return panel.main_widget.data
+
+    @StaticGuiCall
+    def get_data_name() -> str:
+        """Get the name of the data from the current panel"""
+        panel = gui.qapp.panels.selected('ndim')
+        return panel.main_widget.data_name
+
+    @StaticGuiCall
+    def get_dim_names() -> list[str]:
+        """Get the names of the dimensions from the current panel"""
+        panel = gui.qapp.panels.selected('ndim')
+        return panel.main_widget.dim_names
+
+    @StaticGuiCall
+    def get_dim_scales() -> list[tuple[str | None, list | None]]:
+        """Get the scales of the dimensions from the current panel"""
+        panel = gui.qapp.panels.selected('ndim')
+        return panel.main_widget.dim_scales
 
     @StaticGuiCall
     def hide_row_column_color_selection():


### PR DESCRIPTION
An `xarray.DataArray` has more metadata than a regular `ndarray`.

So we can use this metadata to annotate the ndim widgets.

* Use DataArray dimension names to detect rows/cols (y/x) based on name.
* Use DataArray dimension names as 'dim_names'.
* Use DataArray 'coords' as dim_scales.  Also include the coords unit in the scale name.

Note: it's feasible to detect the 'color' dimension by directly looking at the dimension name instead of relying on the dimension size.  This is not implemented.