### PR TITLE
dev: Fix main window placement on old PyQt5 backend

### DIFF
--- a/gdesk/panels/panels.py
+++ b/gdesk/panels/panels.py
@@ -195,12 +195,13 @@ class Panels(object):
         return panel
 
     def place_window(self, window, category):        
-        # screen = QtWidgets.QDesktopWidget().screenNumber(self.qapp.windows['main'])
-        # desktop_rect = QtWidgets.QDesktopWidget().availableGeometry(screen)
-        
-        main_screen = self.qapp.windows['main'].screen()
-        desktop_rect = main_screen.availableGeometry()        
-        
+        try:
+            main_screen = self.qapp.windows['main'].screen()
+            desktop_rect = main_screen.availableGeometry()
+        except AttributeError:  # support old PyQt5
+            screen = QtWidgets.QDesktopWidget().screenNumber(self.qapp.windows['main'])
+            desktop_rect = QtWidgets.QDesktopWidget().availableGeometry(screen)
+
         window_rect = window.frameGeometry()
         prior_panel = self.selected(category, -2)
 


### PR DESCRIPTION
There were some i presume old lines commented out which worked for old (5.9.2) PyQt5 backends.
Using these as fallback option.