### PR TITLE
Optional qt dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,12 @@
 
+1.10.0
+------
+
+- Dependencies: Add dependency group (aka 'extra') named `default` (either PySide6 or PySide2).
+- Dependencies: On Python >=3.12, install `pyside6-essentials` instead of the full `pyside6`.
+- Feature: Allow to run as 'gamma-desk' executable.
+
+
 1.10.0.dev0
 -----------
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -18,23 +18,21 @@ Avoid MatPlotLib 3.5.2 because it crashes plotting on PySide6.
 
 Gamma Desk is best tested with PySide2 and PySide6, and to a lesser extent with PyQt5 and PyQt6.
 
-On Python 3.11 and higher, PySide6 is a hard dependency as PySide2 is not available there.
-
-Up until Python 3.10, you must choose the 'extra' `pyside6` or `pyside2`.
+On Python 3.11 and higher, PySide2 is not available.
 
 PySide 6.8.0 (requiring Python >= 3.12) has a bug which breaks qtpy; avoid that specific release.
 
 If you want to use PyQt5 or PyQt6, you have to install it manually and set environment variable `QT_API=pyqt6`.
 
-| Python | PySide6  | PySide2     | PyQt5    | PyQt6    |
-|--------|----------|-------------|----------|----------|
-| 3.14   | default  | unavailable | possible | possible |
-| 3.13   | default  | unavailable | possible | possible |
-| 3.12   | default  | unavailable | possible | possible |
-| 3.11   | default  | unavailable | possible | possible |
-| 3.10   | extra    | extra       | possible | possible |
-| 3.9    | extra    | extra       | possible | possible |
-| 3.8    | extra    | extra       | possible | possible |
+| Python | PySide6 | PySide2     | PyQt5    | PyQt6    |
+|--------|---------|-------------|----------|----------|
+| 3.14   | default | unavailable | possible | possible |
+| 3.13   | default | unavailable | possible | possible |
+| 3.12   | default | unavailable | possible | possible |
+| 3.11   | default | unavailable | possible | possible |
+| 3.10   | extra   | default     | possible | possible |
+| 3.9    | extra   | default     | possible | possible |
+| 3.8    | extra   | default     | possible | possible |
 
 
 ## Numpy

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ As of Gamma Desk v1.10, on Python >= 3.12, the `pyside6` extra installs `pyside6
 instead of `pyside6`, which avoids the large dependency `pyside6-addons`.
 
 
+# Run with uvx
+
+    uvx gamma-desk[default]
+    uvx --from git+https://github.com/thocoo/gamma-desk.git[default] gamma-desk
+
+
 # Usage
 
     python -m gdesk

--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ A Python work environment with image viewers & Plots
 
 # Installation
 
-Gamma Desk requires PySide6 on Python 3.11 and higher.
+Install Gamma Desk with one of the supported Qt backends, or the default one.
 
-    pip install gamma-desk
+    pip install gamma-desk[default]
+    pip install gamma-desk[pyside6]
+    pip install gamma-desk[pyside2]
 
-On 3.8 to 3.10, you can choose between PySide2 or PySide6.
+Backends are `pyside6` (default from 3.11 and up) or `pyside2` (default up to Python 3.10).
+PyQt backends `pyqt6`, `pyqt5` are tested less thoroughly.
 
-    pip install gamma-desk[pyside2] 
-    pip install gamma-desk[pyside6] 
-
-Using PyQt5 or PyQt6 is possible, but not supported.
+As of Gamma Desk v1.10, on Python >= 3.12, the `pyside6` extra installs `pyside6-essentials`
+instead of `pyside6`, which avoids the large dependency `pyside6-addons`.
 
 
 # Usage
@@ -44,6 +45,7 @@ Using PyQt5 or PyQt6 is possible, but not supported.
 or
 
     gdesk
+    gamma-desk
   
 
 # More documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,9 @@ dependencies = [
     "legacy-cgi; python_version > '3.12'",
     "pywinpty<2.0.15; sys_platform=='win32' and python_version<='3.8'",
     "pywinpty; sys_platform=='win32' and python_version>'3.8'",
-    "pyside6<=6.7; python_version=='3.11'",
-    "pyside6>=6.8.1; python_version>='3.12'",
     "numpy<2; python_version<'3.12'",
     "numpy>=2; python_version>='3.12'",
 ]
- 
 
 [project.scripts]
 gdesk = "gdesk.console:argexec"
@@ -65,12 +62,17 @@ pyside2 = [
     "pyside2; python_version<='3.10'",
 ]
 pyside6 = [
-    "pyside6; python_version<='3.10'",
+     "pyside6<=6.7; python_version=='3.11'",
+     "pyside6-essentials>=6.8.1; python_version>='3.12'",
 ]
 pyqt6 = [
     "pyqt6",
 ]
-
+default = [
+    "pyside2; python_version<='3.10'",
+    "pyside6<=6.7; python_version=='3.11'",
+    "pyside6-essentials>=6.8.1; python_version>='3.12'",
+]
 
 [dependency-groups]
 # See COMPATIBILITY.md.
@@ -78,7 +80,6 @@ dev = [
     "pooch; python_version>='3.9'",
     "xarray",
 ]
-
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
 
 [project.scripts]
 gdesk = "gdesk.console:argexec"
-
+gamma-desk = "gdesk.console:argexec"
 
 [project.urls]
 Source = "https://github.com/thocoo/gamma-desk"


### PR DESCRIPTION
Dependencies are always additional, meaning if you have for example PySide6 as core dependencies you will always have it, even if you choose the optional dependency pyqt6 for example. So the only way to do this in a clean manner is to make them all optional. Also added a 'default' optional dependency that uses the correct pyside depending on the python version you are on.

Make the package also executable using its package name. Running 'gamma-desk' does the exact same as running 'gdesk'.

This means you could run it for example like this using uvx:
`uvx --with pyside6 gamma-desk` instead of `uvx --from 'gamma-desk[default]' gdesk`
